### PR TITLE
Add code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,9 +7,8 @@ contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation. The following list is
-not meant to be exhaustive, but merely to enumerate some common kinds of
-behaviors.
+appearance, race, religion, sexual identity and orientation, or any other
+personal characteristic.
 
 ## Our Standards
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -31,6 +31,9 @@ Examples of unacceptable behavior by participants include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
+This list is not meant to be exhaustive, but merely to enumerate some common
+kinds of behaviors.
+
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -58,7 +58,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at daskdevelopers+conduct@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# Dask Code of Conduct
 
 ## Our Pledge
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,7 +7,9 @@ contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+appearance, race, religion, or sexual identity and orientation. This list is
+not meant to be exhaustive, but merely to enumerate some common kinds of
+behaviors.
 
 ## Our Standards
 
@@ -30,9 +32,6 @@ Examples of unacceptable behavior by participants include:
   address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
-
-This list is not meant to be exhaustive, but merely to enumerate some common
-kinds of behaviors.
 
 ## Our Responsibilities
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,7 +7,7 @@ contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation. This list is
+appearance, race, religion, or sexual identity and orientation. The following list is
 not meant to be exhaustive, but merely to enumerate some common kinds of
 behaviors.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -57,7 +57,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at daskdevelopers+conduct@gmail.com. All
+reported by contacting the project team at dask-conduct@googlegroups.com or by
+filling out [this form](https://goo.gl/forms/YHc1pc9POZRH7RDt2). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -54,14 +54,22 @@ address, posting via an official social media account, or acting as an appointed
 representative at an online or offline event. Representation of a project may be
 further defined and clarified by project maintainers.
 
-## Enforcement
+## Reporting & Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at dask-conduct@googlegroups.com or by
-filling out [this form](https://goo.gl/forms/YHc1pc9POZRH7RDt2). All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+reported by contacting the Dask Code of Conduct committee at
+dask-conduct@googlegroups.com or by filling out
+[this form](https://goo.gl/forms/YHc1pc9POZRH7RDt2). Currently, the committee
+consists of:
+
+- James Bourbeau
+- Tom Augspurger
+- Matthew Rocklin
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The committee is
 obligated to maintain confidentiality with regard to the reporter of an incident.
+In addition, the online form allows you to submit a report anonymously.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -39,7 +39,7 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
+Project maintainers have the right to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,


### PR DESCRIPTION
This PR adds a code of conduct for Dask. The starting point is the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct), with modifications made based on discussion in #6 and further discussion to be had here. Closes #6.