### PR TITLE
First draft of Dask trademark policy based on discussion in #4

### DIFF
--- a/trademark.md
+++ b/trademark.md
@@ -40,7 +40,11 @@ Open source projects may also use the Dask name as part of the name of their
 project (Ex: `dask-cuda`) so long as it satisfies *all* the following
 criteria:
 
-* The project is open source with an [OSI-approved](https://opensource.org/licenses/) open source license.
+* The project is open source with an open source license that would permit
+  upstreaming relevant parts of the project into the Dask project (if
+  appropriate).  For example, copyleft licenses would not be allowed, as such
+  code could not be brought into Dask itself without imposing additional
+  license restrictions on Dask users. 
 * The project is related to Dask.
 * The project name should not be overly grand in claiming namespace.
 * The project should not make subjective claims in the name itself.

--- a/trademark.md
+++ b/trademark.md
@@ -1,0 +1,72 @@
+Dask Trademark Policy
+=====================
+
+This document describes the policy governing the use of the "Dask" trademark,
+which is owned by NumFOCUS and administered on behalf of the Dask project.  Any
+use of the Dask trademark commercially or non-commercially must be in
+accordance with the policy described in this document unless specific written
+permission is obtained from NumFOCUS.
+
+Usage and modification of the Dask *software* is governed by the
+[license](https://github.com/dask/dask/blob/main/LICENSE.txt), which describes
+permissable behavior under copyright law.  Trademarks are a distinct form of
+intellectual property, and so the guidelines in this document apply only to
+the "Dask" trademark and logo, but not to the software itself.
+
+Intent
+------
+
+Our goal is to enable the Dask trademark and logo to be used with minimal
+restrictions by both commercial and non-commercial entities, but we do *not*
+want the Dask trademark to be used:
+
+* to cause confusion about whether a project, product, or service is endorsed
+  by the Dask community in some way.
+* in a way that allows an entity to misleadingly imply ownership of Dask or
+  influence over the Dask project.
+
+Permissable usage
+-----------------
+
+The Dask trademark is always subject to "nominative use rules" which allow the
+usage of the trademark for descriptive purposes that does not suggest
+sponsorship or endorsement by the trademark owner.  You may freely describe
+that your product or service "uses Dask" or is "powered by Dask," and you
+may use the unaltered Dask logo to indicate this without prior approval.
+(Please see the [Dask Brand Guide](https://www.dask.org/brand-guide) for more
+details about how to use the Dask logo.)
+
+Open source projects may also use the Dask name as part of the name of their
+project (Ex: `dask-cuda`) so long as it satisfies *all* the following
+criteria:
+
+* The project is open source with a liberal license.
+* The project is related to Dask.
+* The project name should not be overly grand in claiming namespace.
+* The project should not make subjective claims in the name itself.
+
+Usage of the "Dask" trademark should also be consistent with the [Dask Code of Conduct](https://github.com/dask/governance/blob/main/code-of-conduct.md).
+
+Non-permissible usage
+---------------------
+
+The Dask trademark may *not* be used in a commercial product or company name.  Examples of disallowed uses include:
+
+* Dask Pro
+* Dask Enterprise
+* The Dask Company
+* CompanyName Dask
+
+Company and product logos may not derive from the Dask logo in a way that would cause brand confusion.
+
+Where to get more information
+-----------------------------
+
+If you are unsure whether your planned usage of the Dask trademark is allowed,
+or feel that you need specific written approval for your situation, please
+contact NumFOCUS at *INSERT CONTACT EMAIL HERE*.
+
+Acknowledgements
+----------------
+
+This document is the result of the community discussion found in [dask/governance#4](https://github.com/dask/governance/issues/4).  It draws inspiration from both the [PSF Trademark Policy](https://www.python.org/psf/trademarks/) and the Model Trademark Guidelines, available at http://www.modeltrademarkguidelines.org.

--- a/trademark.md
+++ b/trademark.md
@@ -9,7 +9,7 @@ permission is obtained from NumFOCUS.
 
 Usage and modification of the Dask *software* is governed by the
 [license](https://github.com/dask/dask/blob/main/LICENSE.txt), which describes
-permissable behavior under copyright law.  Trademarks are a distinct form of
+permissible behavior under copyright law.  Trademarks are a distinct form of
 intellectual property, and so the guidelines in this document apply only to
 the "Dask" trademark and logo, but not to the software itself.
 
@@ -25,7 +25,7 @@ want the Dask trademark to be used:
 * in a way that allows an entity to misleadingly imply ownership of Dask or
   influence over the Dask project.
 
-Permissable usage
+Permissible usage
 -----------------
 
 The Dask trademark is always subject to "nominative use rules" which allow the
@@ -64,7 +64,7 @@ Where to get more information
 
 If you are unsure whether your planned usage of the Dask trademark is allowed,
 or feel that you need specific written approval for your situation, please
-contact NumFOCUS at *INSERT CONTACT EMAIL HERE*.
+contact the Dask maintainers at info@dask.org.
 
 Acknowledgements
 ----------------

--- a/trademark.md
+++ b/trademark.md
@@ -40,7 +40,7 @@ Open source projects may also use the Dask name as part of the name of their
 project (Ex: `dask-cuda`) so long as it satisfies *all* the following
 criteria:
 
-* The project is open source with a liberal license.
+* The project is open source with an [OSI-approved](https://opensource.org/licenses/) open source license.
 * The project is related to Dask.
 * The project name should not be overly grand in claiming namespace.
 * The project should not make subjective claims in the name itself.


### PR DESCRIPTION
This is a summary of trademark policy that emerged in discussion in issue #4.  The text assumes that ownership of the Dask trademark has been transferred to NumFOCUS, which is in progress.

The text is currently fairly minimal to only capture the specific nuance of how the Dask community wants its trademark to be used.  Both the [PSF Trademark Users Guide](https://www.python.org/psf/trademarks/) and the [NumFOCUS Trademark Guidelines](https://numfocus.org/trademark-guidelines) have a lot more generic boilerplate about how trademarks are used in general which we could add here if we want.

One TBD part of the document is where we want inquires about the trademark policy to go.  Should they go to admin@numfocus.org or is there a Dask-specific email where questions should go?

(Marking this PR as draft until that last bit of text is figured out, but please add review comments now if you want.)