### PR TITLE
Clean up ownership governance

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -31,6 +31,8 @@ Examples of unacceptable behavior by participants include:
   address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
+* Publishing spam or other advertising unrelated to Dask or that does not
+  benefit the Dask community
 
 ## Our Responsibilities
 
@@ -64,6 +66,7 @@ consists of:
 - James Bourbeau
 - Tom Augspurger
 - Matthew Rocklin
+- Jacob Tomlinson
 
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The committee is

--- a/governance.md
+++ b/governance.md
@@ -117,8 +117,8 @@ long-term well-being of the project, both technically and as a community.
 During the everyday project activities, council members participate in all
 discussions, code review and other project activities as peers with all other
 Contributors and the Community. In these everyday activities, Council Members
-do not have any special power or privilege through their membership on the
-Council. However, it is expected that because of the quality and quantity of
+are granted Owner status on GitHub giving them write access to the organization.
+It is expected that because of the quality and quantity of
 their contributions and their expert knowledge of the Project Software and
 Services that Council Members will provide useful guidance, both technical and
 in terms of project direction, to potentially less experienced contributors.
@@ -157,9 +157,11 @@ quality and quantity
    work interests or sub-project
 -  Be civil in public discourse
 
-Potential Council Members are nominated by existing Council members and voted
-upon by the existing Council after asking if the potential Member is interested
-and willing to serve in that capacity. The Council will be initially formed
+Potential Council Members are nominated by existing Council members and made by lazy
+consensus of existing Council Members after asking if the potential Member is interested
+and willing to serve in that capacity. Any -1 vote bars a candidate.  We ask that a
+majority of owners respond for quorum, and that those votes come from people
+employed/associated to at least three institutions. The Council will be initially formed
 from the set of existing Core Developers who, as of 2019, have ownership rights
 over the organization.
 
@@ -170,12 +172,8 @@ to active participation. If not, they will be removed immediately upon a Council
 vote. If they plan to return to active participation soon, they will be
 given a grace period of one year. If they don’t return to active participation
 within that time period they will be removed by vote of the Council without
-further grace period. All former Council members can be considered for
-membership again at any time in the future, like any other Project Contributor.
-Retired Council members will be listed on the project website, acknowledging
-the period during which they were active in the Council.
-An inactive BDFL may also be ejected by a vote of current Council members under
-these same conditions.
+further grace period. An inactive BDFL may also be ejected by a vote of current
+Council members under these same conditions.
 
 The Council reserves the right to eject current Members, other than the BDFL,
 if they are deemed to be actively harmful to the project’s well-being, and
@@ -186,8 +184,23 @@ Code of Conduct) and not other technical reasons (e.g. we have different
 viewpoints on project direction) or personal reasons (e.g. they belong to a
 competitor's organization). We ask that a majority of Steering Council members
 respond for quorum, and that those votes come from people employed/associated
-with at least three institutions.
+with at least two institutions.
 
+### Emeritus council members
+
+When a member leaves the Council due to inactivity they automatically become an
+Emeritus Council Member where they can continue to provide the same expert guidance
+to the community but without the Ownership status on GitHub or any voting rights.
+
+Members that are ejected by council vote for harmful behaviour they will not be given
+this status.
+
+All Emeritus Council members who become active again in the project can request to be
+reinstated to full Council Members. A majority vote of active owners is required to veto
+this reinstatement.
+
+Emeritus Council members will be listed on the project website, acknowledging
+the period during which they were active in the Council.
 
 ### Conflict of interest
 

--- a/governance.md
+++ b/governance.md
@@ -161,7 +161,7 @@ Potential Council Members are nominated by existing Council members and made by 
 consensus of existing Council Members after asking if the potential Member is interested
 and willing to serve in that capacity. Any -1 vote bars a candidate.  We ask that a
 majority of owners respond for quorum, and that those votes come from people
-employed/associated to at least three institutions. The Council will be initially formed
+employed/associated to at least two institutions. The Council will be initially formed
 from the set of existing Core Developers who, as of 2019, have ownership rights
 over the organization.
 

--- a/governance.md
+++ b/governance.md
@@ -192,7 +192,7 @@ When a member leaves the Council due to inactivity they automatically become an
 Emeritus Council Member where they can continue to provide the same expert guidance
 to the community but without the Ownership status on GitHub or any voting rights.
 
-Members that are ejected by council vote for harmful behaviour they will not be given
+Members that are ejected by council vote for harmful behavior will not be given
 this status.
 
 All Emeritus Council members who become active again in the project can request to be

--- a/membership.md
+++ b/membership.md
@@ -8,7 +8,7 @@ GitHub organization and commit rights to Dask repositories.
 Owners
 ------
 
-The [Steering Coucil](./governance.md#steering-council) members have ownership
+The [Steering Council](./governance.md#steering-council) members have ownership
 privileges over the entire GitHub organization.  As a result, they have commit
 rights to all repositories and are involved in creating and removing members.
 These individuals are listed at https://github.com/orgs/dask/people.

--- a/membership.md
+++ b/membership.md
@@ -8,25 +8,20 @@ GitHub organization and commit rights to Dask repositories.
 Owners
 ------
 
-There is a set of individuals who have ownership privileges over the entire
-GitHub organization.  As a result, they have commit rights to all repositories
-and are involved in creating and removing members.  These individuals are
-listed at https://github.com/orgs/dask/people .
+The [Steering Coucil](./governance.md#steering-council) members have ownership
+privileges over the entire GitHub organization.  As a result, they have commit
+rights to all repositories and are involved in creating and removing members.
+These individuals are listed at https://github.com/orgs/dask/people.
 
 We ask that owners ensure that their membership is public.
-
-New owners are made by lazy consensus of previous owners.  All owners will be
-made aware of a new candidate.  Any -1 vote bars a candidate.  We ask that a
-majority of owners respond for quorum, and that those votes come from people
-employed/associated to at least three institutions.
-
 
 Members
 -------
 
 New members can be made by any owner if the following criteria are met:
 
-1.  At least two owners from separate employers agree membership is a good idea
+1.  At least two steering council members from separate employers agree membership
+    is a good idea.
 2.  The new member has supported the project several times, either through code
     or otherwise, and has demonstrated a willingness to help solve other
     people's problems, not just their own.
@@ -47,7 +42,7 @@ above conditions and the following:
     and not just their own problems or the problems of their organization.
 
 In the case of the more critical repositories (dask/dask, dask/distributed)
-then at least three owners should agree to give privileges.
+then at least three steering council members should agree to give privileges.
 
 Teams
 -----
@@ -55,27 +50,27 @@ Teams
 We acknowledge that write permissions to individual projects may be better handled by teams.  Team membership will be handled similar to write permissions.
 
 
-Removing permissions
---------------------
+Removing write privileges
+-------------------------
 
-People's permissions can be removed in a two-step process:
+Non-steering Council members permissions can be removed in a two-step process:
 
 1.  After a year of inactivity they are sent a private message noting that they
     have been inactive and asking if they'd still like to maintain their
-    permissions.  No response after a suitable time (two weeks) will default in
-    removal of permissions
-2.  After two years of inactivity their permissions are removed regardless
+    permissions.  No further activity after a suitable time (two weeks) will
+    default in removal of permissions.
+2.  After two years of inactivity their permissions are removed regardless.
 
 We intentionally call out that "activity" can mean a great many things
 including but not limited to writing code, documenting, being active on issues,
 supporting users, etc..  Activity should be more than token events to maintain
-permissions
+permissions.
 
-Any owner may temporarily remove permissions of any non-owner if there is some
-pressing reason to do so, such as insecure credentials.  A consensus of owners
-can remove permissions of anyone long-term.  We ask that a majority of owners
-respond for quorum, and that those votes come from people employed/associated
-to at least three institutions.
+Any steering council member may temporarily remove permissions of any non-owner
+if there is some pressing reason to do so, such as insecure credentials.
+A consensus of steering council members can remove permissions of anyone long-term.
+We ask that a majority of steering council members respond for quorum, and that those
+votes come from people employed/associated with more than one institution.
 
 
 Exception Handling


### PR DESCRIPTION
This PR attempts to update the Dask governance to better represent the current state of Dask Ownership.

I've tried to incorporate everything from all of the discussions I've had with folks about this lately, but feedback is very welcome. I want to be sure I have accurately reflected things.

Key changes:
- Make it clear that "Steering Council" and "Owners" are the same thing.
- Reduce duplication around how folks join the Steering Council.
- Add explanation that inactive Council Members lose ownership rights and voting power and become Emeritus Council Members. 
- Emeritus Council Members can restore their permissions by simply being active again, but this can be vetoed by the active council.
- Currently, the Council only has employees from two institutions so updating voting rules to reflect that. It would be nice to restore this in the future though.

@mrocklin @jrbourbeau @quasiben @fjetter 